### PR TITLE
CentOS check, quote fix

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,10 @@ class ipaclient::params {
   case $::osfamily {
     RedHat: {
       case $::operatingsystem {
-        RedHat: {
+        'RedHat': {
+          $ipa_package = 'ipa-client'
+        }
+        'CentOS': {
           $ipa_package = 'ipa-client'
         }
         default: {


### PR DESCRIPTION
- Added a check for CentOS.  It was trying to install freeipa-client otherwise, which broke the module.
- Added quotes around both $::operatingsystem values.
