### PR TITLE
More quick fixes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,7 +85,7 @@ class ipaclient (
   }
 
   # Build the installation comamnd:
-  if $join_user             {  $user    = "--principal ${join_user}\@${ipa_realm}"}
+  if $join_user             {  $user    = "--principal ${join_user}\\@${ipa_realm}"}
   if $mkhomedir             {  $homedir = ' --mkhomedir'}
   if $ipa_realm != 'UNSET'  {  $realm   = "--realm ${ipa_realm}" }
   if $enrollment_host       {  $enroll  = "--server ${enrollment_host}" }

--- a/templates/sudo-ldap.erb
+++ b/templates/sudo-ldap.erb
@@ -1,9 +1,9 @@
-binddn uid=sudo,cn=sysaccounts,cn=etc,<%= domain_dn %>
-bindpw <%= sudo_bindpw %>
+binddn uid=sudo,cn=sysaccounts,cn=etc,<%= @domain_dn %>
+bindpw <%= @sudo_bindpw %>
 ssl start_tls
 tls_cacertfile /etc/ipa/ca.crt
 tls_checkpeer yes
 bind_timelimit 5
 timelimit 15
-uri <% replicas.each do |replica| -%>ldap://<%= replica -%> <% end %>
-sudoers_base ou=SUDOers,<%= domain_dn %>
+uri <% @replicas.each do |replica| -%>ldap://<%= replica -%> <% end %>
+sudoers_base ou=SUDOers,<%= @domain_dn %>


### PR DESCRIPTION
Using Puppet 3.4.2, it doesn't like the single '\' or the lack of '@' in erb templates.  Patch attached...
