### PR TITLE
Support for RHEL6.6 and RHEL7 sudo automatic config

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,8 @@
 # $mkhomedir::             Automatically make /home/<user> or not
 #                          Default: true
 #
+# $needs_sudo_config       Manually configure sudo? (Boolean)
+#
 # $ntp::                   Manage and configure ntpd?
 #                          Default: true
 #
@@ -53,8 +55,6 @@
 #
 # $sudo::                  Enable sudoers management
 #                          Default: true
-#
-# $version::               IPA client version
 #
 # === Examples
 #
@@ -94,6 +94,7 @@ class ipaclient (
   $force              = $ipaclient::params::force,
   $installer          = $ipaclient::params::installer,
   $mkhomedir          = $ipaclient::params::mkhomedir,
+  $needs_sudo_config  = $ipaclient::params::needs_sudo_config,
   $ntp                = $ipaclient::params::ntp,
   $options            = $ipaclient::params::options,
   $package            = $ipaclient::params::package,
@@ -104,7 +105,6 @@ class ipaclient (
   $ssh                = $ipaclient::params::ssh,
   $sshd               = $ipaclient::params::sshd,
   $sudo               = $ipaclient::params::sudo,
-  $version            = $ipaclient::params::version
 ) inherits ipaclient::params {
 
   package { $package:
@@ -213,9 +213,7 @@ class ipaclient (
     }
   }
 
-  # ipa-client =>4 handles sudo configuration automatically,
-  # so we can skip the stuff below
-  if (str2bool($sudo) and $version < 4) {
+  if (str2bool($sudo) and str2bool($needs_sudo_config)) {
     # If user didn't specify a server, use the fact.  Otherwise pass in
     # the first value of server parameter
     if empty($server) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,24 +22,35 @@ class ipaclient::params {
   $automount_server   = ''
   $ntp            = true
   $force          = false
+  $sssd_sudo_cache_timeout     = ''
+  $sssd_sudo_full_refresh      = ''
+  $sssd_sudo_smart_refresh     = ''
+  $sssd_default_domain_suffix  = ''
 
   # Determine if client needs manual sudo configuration or not
-  # RHEL =>6.6 sudo configuration is automatic 
+  # RHEL <=6.5 requires manual configuration
+  # RHEL 6.6 includes automatic sudo configuration
+  # RHEL 7.0 requires manual confifuration
+  # RHEL >=7.1 includes automatic sudo configuration
   case $::osfamily {
     RedHat: {
       case $::operatingsystem {
         'Fedora': {
           if (versioncmp($::operatingsystemrelease, '21') >= 0) {
-            $needs_sudo_config = '0'
+            $needs_sudo_config = false 
           } else {
-            $needs_sudo_config = '1'
+            $needs_sudo_config = true
           }
         }
         default: {
           if (versioncmp($::operatingsystemrelease, '6.6') >= 0) {
-            $needs_sudo_config = '0'
+            if (versioncmp($::operatingsystemrelease, '7.0') == 0) {
+              $needs_sudo_config = true
+            } else {
+              $needs_sudo_config = false
+            }
           } else {
-            $needs_sudo_config = '1'
+            $needs_sudo_config = true
           }
         }
       }
@@ -48,13 +59,13 @@ class ipaclient::params {
       case $::operatingsystem {
         'Ubuntu': {
           if (versioncmp($::operatingsystemrelease, '15.04') > 0) {
-            $needs_sudo_config = '0'
+            $needs_sudo_config = false
           } else {
-            $needs_sudo_config = '1'
+            $needs_sudo_config = true
           }
         }
         default: {
-          $needs_sudo_config = '1'
+          $needs_sudo_config = true
         }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,22 +23,23 @@ class ipaclient::params {
   $ntp            = true
   $force          = false
 
-  # Version of IPA client
+  # Determine if client needs manual sudo configuration or not
+  # RHEL =>6.6 sudo configuration is automatic 
   case $::osfamily {
     RedHat: {
       case $::operatingsystem {
         'Fedora': {
           if (versioncmp($::operatingsystemrelease, '21') >= 0) {
-            $version = '4'
+            $needs_sudo_config = '0'
           } else {
-            $version = '3'
+            $needs_sudo_config = '1'
           }
         }
         default: {
-          if (versioncmp($::operatingsystemrelease, '7.1') >= 0) {
-            $version = '4'
+          if (versioncmp($::operatingsystemrelease, '6.6') >= 0) {
+            $needs_sudo_config = '0'
           } else {
-            $version = '3'
+            $needs_sudo_config = '1'
           }
         }
       }
@@ -47,13 +48,13 @@ class ipaclient::params {
       case $::operatingsystem {
         'Ubuntu': {
           if (versioncmp($::operatingsystemrelease, '15.04') > 0) {
-            $version = '4'
+            $needs_sudo_config = '0'
           } else {
-            $version = '3'
+            $needs_sudo_config = '1'
           }
         }
         default: {
-          $version = '3'
+          $needs_sudo_config = '1'
         }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,45 @@ class ipaclient::params {
   $ntp            = true
   $force          = false
 
+  # Version of IPA client
+  case $::osfamily {
+    RedHat: {
+      case $::operatingsystem {
+        'Fedora': {
+          if (versioncmp($::operatingsystemrelease, '21') >= 0) {
+            $version = '4'
+          } else {
+            $version = '3'
+          }
+        }
+        default: {
+          if (versioncmp($::operatingsystemrelease, '7.1') >= 0) {
+            $version = '4'
+          } else {
+            $version = '3'
+          }
+        }
+      }
+    }
+    Debian: {
+      case $::operatingsystem {
+        'Ubuntu': {
+          if (versioncmp($::operatingsystemrelease, '15.04') > 0) {
+            $version = '4'
+          } else {
+            $version = '3'
+          }
+        }
+        default: {
+          $version = '3'
+        }
+      }
+    }
+    default: {
+      fail("This module does not support operatingsystem ${::operatingsystem}")
+    }
+  }
+
   # Name of IPA package to install
   case $::osfamily {
     RedHat: {

--- a/spec/classes/ipaclient_spec.rb
+++ b/spec/classes/ipaclient_spec.rb
@@ -106,10 +106,28 @@ describe 'ipaclient' do
       end
 
       it "should generate the correct command" do
-        should contain_exec('ipa_installer').with_command("/usr/sbin/ipa-client-install --realm PIXIEDUST.COM --password unicorns --principal rainbows@PIXIEDUST.COM --domain pixiedust.com --server ipa01.pixiedust.com --no-sshd --no-ntp --force --unattended")
+        should contain_exec('ipa_installer').with_command("/usr/sbin/ipa-client-install --realm PIXIEDUST.COM --password unicorns --principal rainbows@PIXIEDUST.COM --domain pixiedust.com --server ipa01.pixiedust.com --no-sshd --no-ntp --no-sudo --force --unattended")
       end
 
       it "should not configure sudoers" do
+        should_not contain_class('ipaclient::sudoers')
+      end
+    end
+
+    describe "with automount and sudoers for ipa-client 4" do
+      let :params do {
+          :password  => 'unicorns',
+          :principal => 'rainbows',
+          :server    => 'ipa01.pixiedust.com',
+          :domain    => 'pixiedust.com',
+          :realm     => 'PIXIEDUST.COM',
+          :automount => true,
+          :automount_location => 'home',
+          :sudo      => true,
+          :version   => '4'
+      } end
+
+      it "should not configure sudo" do
         should_not contain_class('ipaclient::sudoers')
       end
     end

--- a/spec/classes/ipaclient_spec.rb
+++ b/spec/classes/ipaclient_spec.rb
@@ -124,7 +124,7 @@ describe 'ipaclient' do
           :automount => true,
           :automount_location => 'home',
           :sudo      => true,
-          :version   => '4'
+          :needs_sudo_config   => '0'
       } end
 
       it "should not configure sudo" do


### PR DESCRIPTION
This PR adds support for the 'automatic sudo' configuration that is now present in RHEL =>6.6 (F21+).
- Add an option for specifying '--no-sudo' for ipa-client-install to completely disable automatic and manual sudo configuration.
- Add a new parameter named $needs_sudo_config to determine if the client needs manual sudo confiruation (<6.6).
