### PR TITLE
Add sssd related paramaters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,52 +9,63 @@
 #
 # All Parameters:
 #
-# $automount::             Enable automount
-#                          Default: false
+# $automount::                    Enable automount
+#                                 Default: false
 #
-# $automount_location::    Automounter location
+# $automount_location::           Automounter location
 #
-# $automount_server::      Automounter server
+# $automount_server::             Automounter server
 #
-# $domain::                Domain, e.g. pixiedust.com
+# $domain::                       Domain, e.g. pixiedust.com
 #
-# $fixed_primary::         Used a fixed primary
-#                          Default: false
+# $fixed_primary::                Used a fixed primary
+#                                 Default: false
 #
-# $force::                 Enable "forced" installation mode
-#                          Default: false
+# $force::                        Enable "forced" installation mode
+#                                 Default: false
 #
-# $installer::             IPA install command
+# $installer::                    IPA install command
 #
-# $mkhomedir::             Automatically make /home/<user> or not
-#                          Default: true
+# $mkhomedir::                    Automatically make /home/<user> or not
+#                                 Default: true
 #
-# $needs_sudo_config       Manually configure sudo? (Boolean)
+# $needs_sudo_config              Manually configure sudo? (Boolean)
 #
-# $ntp::                   Manage and configure ntpd?
-#                          Default: true
+# $ntp::                          Manage and configure ntpd?
+#                                 Default: true
 #
-# $options::               Additional command-line options to pass directly to
-#                          installer
+# $options::                      Additional command-line options to pass directly to
+#                                 installer
 #
-# $package::               Package to install
+# $package::                      Package to install
 #
-# $password::              One-time password, or registration user's password
+# $password::                     One-time password, or registration user's password
 #
-# $principal::             Kerberos principal when not using one-time passwords
+# $principal::                    Kerberos principal when not using one-time passwords
 #
-# $realm::                 Realm, e.g. PIXIEDUST.COM
+# $realm::                        Realm, e.g. PIXIEDUST.COM
 #
-# $server::                Can be array or string of IPA servers
+# $server::                       Can be array or string of IPA servers
 #
-# $ssh::                   Enable SSH Integation
-#                          Default: true
+# $ssh::                          Enable SSH Integation
+#                                 Default: true
 #
-# $sshd::                  Enable SSHD Integration
-#                          Default: true
+# $sshd::                         Enable SSHD Integration
+#                                 Default: true
 #
-# $sudo::                  Enable sudoers management
-#                          Default: true
+# $sssd_sudo_cache_timeout        How many seconds should sudo consider rules valid before
+#                                 asking the backend again
+#
+# $sssd_sudo_full_refresh         How many seconds sssd will wait before executing
+#                                 a full refresh of sudo rules
+#
+# $sssd_sudo_smart_refresh        How many seconds sssd will wait before executing
+#                                 a smart refresh of sudo rules
+#
+# $sssd_default_domain_suffix     The default domain suffix for sssd
+#
+# $sudo::                         Enable sudoers management
+#                                 Default: true
 #
 # === Examples
 #
@@ -86,25 +97,29 @@
 # Released under the MIT License. See LICENSE for more information
 #
 class ipaclient (
-  $automount          = $ipaclient::params::automount,
-  $automount_location = $ipaclient::params::automount_location,
-  $automount_server   = $ipaclient::params::automount_server,
-  $domain             = $ipaclient::params::domain,
-  $fixed_primary      = $ipaclient::params::fixed_primary,
-  $force              = $ipaclient::params::force,
-  $installer          = $ipaclient::params::installer,
-  $mkhomedir          = $ipaclient::params::mkhomedir,
-  $needs_sudo_config  = $ipaclient::params::needs_sudo_config,
-  $ntp                = $ipaclient::params::ntp,
-  $options            = $ipaclient::params::options,
-  $package            = $ipaclient::params::package,
-  $password           = $ipaclient::params::password,
-  $principal          = $ipaclient::params::principal,
-  $realm              = $ipaclient::params::realm,
-  $server             = $ipaclient::params::server,
-  $ssh                = $ipaclient::params::ssh,
-  $sshd               = $ipaclient::params::sshd,
-  $sudo               = $ipaclient::params::sudo,
+  $automount                  = $ipaclient::params::automount,
+  $automount_location         = $ipaclient::params::automount_location,
+  $automount_server           = $ipaclient::params::automount_server,
+  $domain                     = $ipaclient::params::domain,
+  $fixed_primary              = $ipaclient::params::fixed_primary,
+  $force                      = $ipaclient::params::force,
+  $installer                  = $ipaclient::params::installer,
+  $mkhomedir                  = $ipaclient::params::mkhomedir,
+  $needs_sudo_config          = $ipaclient::params::needs_sudo_config,
+  $ntp                        = $ipaclient::params::ntp,
+  $options                    = $ipaclient::params::options,
+  $package                    = $ipaclient::params::package,
+  $password                   = $ipaclient::params::password,
+  $principal                  = $ipaclient::params::principal,
+  $realm                      = $ipaclient::params::realm,
+  $server                     = $ipaclient::params::server,
+  $ssh                        = $ipaclient::params::ssh,
+  $sshd                       = $ipaclient::params::sshd,
+  $sssd_sudo_cache_timeout    = $ipaclient::params::sssd_sudo_cache_timeout,
+  $sssd_sudo_full_refresh     = $ipaclient::params::sssd_sudo_full_refresh,
+  $sssd_sudo_smart_refresh    = $ipaclient::params::sssd_sudo_smart_refresh,
+  $sssd_default_domain_suffix = $ipaclient::params::sssd_default_domain_suffix,
+  $sudo                       = $ipaclient::params::sudo,
 ) inherits ipaclient::params {
 
   package { $package:
@@ -245,5 +260,13 @@ class ipaclient (
         require  => $installer_resource,
     }
   }
+
+  class { 'ipaclient::sssd':
+    sssd_sudo_cache_timeout    => $sssd_sudo_cache_timeout,
+    sssd_sudo_full_refresh     => $sssd_sudo_full_refresh,
+    sssd_sudo_smart_refresh    => $sssd_sudo_smart_refresh,
+    sssd_default_domain_suffix => $sssd_default_domain_suffix,
+  }
+
 }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,7 @@ class ipaclient::params {
       case $::operatingsystem {
         'Fedora': {
           if (versioncmp($::operatingsystemrelease, '21') >= 0) {
-            $needs_sudo_config = false 
+            $needs_sudo_config = false
           } else {
             $needs_sudo_config = true
           }

--- a/manifests/sssd.pp
+++ b/manifests/sssd.pp
@@ -1,0 +1,67 @@
+# == Class: ipaclient::sssd
+#
+# Configures sssd for IPA
+#
+# === Parameters
+#
+# === Authors
+#
+# Stephen Benjamin <stephen@bitbin.de>
+#
+# === Copyright
+#
+# Copyright 2014 Stephen Benjamin.
+# Released under the MIT License. See LICENSE for more information
+#
+class ipaclient::sssd(
+  $sssd_sudo_cache_timeout    = $ipaclient::params::sssd_sudo_cache_timeout,
+  $sssd_sudo_full_refresh     = $ipaclient::params::sssd_sudo_full_refresh,
+  $sssd_sudo_smart_refresh    = $ipaclient::params::sssd_sudo_smart_refresh,
+  $sssd_default_domain_suffix = $ipaclient::params::sssd_default_domain_suffix
+) inherits ipaclient::params {
+
+  service { 'sssd':
+    ensure  => running,
+    enable  => true,
+  }
+
+  if !empty($sssd_sudo_cache_timeout) {
+    augeas { 'sudo_cache_timeout':
+      context => '/files/etc/sssd/sssd.conf',
+      changes => [
+        "set target[1]/entry_cache_sudo_timeout ${sssd_sudo_cache_timeout}",
+      ],
+      notify => Service['sssd'],
+    }
+  }
+
+  if !empty($sssd_sudo_full_refresh) {
+    augeas { 'sudo_full_refresh':
+      context => '/files/etc/sssd/sssd.conf',
+      changes => [
+        "set target[5]/ldap_sudo_full_refresh_interval ${sssd_sudo_full_refresh}",
+      ],
+      notify => Service['sssd'],
+    }
+  }
+
+  if !empty($sssd_sudo_smart_refresh) {
+    augeas { 'sudo_smart_refresh':
+      context => '/files/etc/sssd/sssd.conf',
+      changes => [
+        "set target[5]/ldap_sudo_smart_refresh_interval ${sssd_sudo_smart_refresh}",
+      ],
+      notify => Service['sssd'],
+    }
+  }
+
+  if !empty($sssd_default_domain_suffix) {
+    augeas { 'default_domain_suffix':
+      context => '/files/etc/sssd/sssd.conf',
+      changes => [
+        "set target[2]/default_domain_suffix ${sssd_default_domain_suffix}",
+      ],
+      notify => Service['sssd'],
+    }
+  }
+}

--- a/manifests/sudoers.pp
+++ b/manifests/sudoers.pp
@@ -78,12 +78,6 @@ class ipaclient::sudoers (
       ensure  => installed,
     }
 
-    service { 'sssd':
-      ensure  => running,
-      enable  => true,
-      require => Package[$libsss_sudo_package],
-    }
-
     augeas { 'nsswitch_sudoers':
       context => '/files/etc/nsswitch.conf',
       changes => [

--- a/spec/classes/ipaclient_sssd_spec.rb
+++ b/spec/classes/ipaclient_sssd_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe 'ipaclient::sssd' do
+  context "RedHat" do
+    let :facts do {
+      :ipa_domain                 => 'pixiedust.com',
+      :fqdn                       => 'host.pixiedust.com',
+      :osfamily                   => 'RedHat',
+    } end
+    let :params do {
+      :sssd_sudo_cache_timeout    => '1800',
+      :sssd_sudo_full_refresh     => '10800',
+      :sssd_sudo_smart_refresh    => '600',
+      :sssd_default_domain_suffix => 'pixiedust.com',
+    } end
+
+    it "should configure custom cache and refresh intervals" do
+      should contain_augeas('sudo_cache_timeout')
+      should contain_augeas('sudo_full_refresh')
+      should contain_augeas('sudo_smart_refresh')
+    end
+
+    describe_augeas 'sudo_cache_timeout', :lens => 'Sssd', :target => '/etc/sssd/sssd.conf' do
+      it "should configure custom sssd cache timeout" do
+        should execute.with_change
+        aug_get("target[1]/entry_cache_sudo_timeout").should == '1800'
+        should execute.idempotently
+      end
+    end
+
+     describe_augeas 'sudo_full_refresh', :lens => 'Sssd', :target => '/etc/sssd/sssd.conf' do
+       it "should configure custom sudo full refresh timer" do
+         should execute.with_change
+         aug_get("target[5]/ldap_sudo_full_refresh_interval").should == '10800'
+         should execute.idempotently
+       end
+     end
+
+     describe_augeas 'sudo_smart_refresh', :lens => 'Sssd', :target => '/etc/sssd/sssd.conf' do
+       it "should configure custom sudo smart refresh timer" do
+         should execute.with_change
+         aug_get("target[5]/ldap_sudo_smart_refresh_interval").should == '600'
+         should execute.idempotently
+       end
+     end
+
+     it "should configure custom sssd default domain suffix" do
+       should contain_augeas('default_domain_suffix')
+     end
+
+     describe_augeas 'default_domain_suffix', :lens => 'Sssd', :target => '/etc/sssd/sssd.conf' do
+       it "should configure custom sssd default domain suffix" do
+         should execute.with_change
+         aug_get("target[2]/default_domain_suffix").should == 'pixiedust.com'
+         should execute.idempotently
+       end
+     end
+  end
+end


### PR DESCRIPTION
This PR adds several new parameters that allow you to control sudo cache settings for sssd.  It also adds a new class, ipaclient::sssd.
