### PR TITLE
Update automount.pp

### DIFF
--- a/manifests/automount.pp
+++ b/manifests/automount.pp
@@ -41,6 +41,6 @@ class ipaclient::automount(
 
   exec { 'enable_automount':
     command => $command,
-    unless  => '/bin/grep -qE "automount:\s+sss" /etc/nsswitch.conf',
+    unless  => '/bin/grep -qE "^automount:(\s+files\s+sss|\s+sss)" /etc/nsswitch.conf',
   }
 }


### PR DESCRIPTION
handles the case of "automount: files sss" in /etc/nsswitch.conf 
also keeps ""#automount: sss" from matching
