### PR TITLE
Add hostname option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,8 @@
 # $sudo::                  Enable sudoers management
 #                          Default: true
 #
+# $hostname::              Client FQDN
+#
 # === Examples
 #
 # Discovery register example:
@@ -105,6 +107,7 @@ class ipaclient (
   $ssh                = $ipaclient::params::ssh,
   $sshd               = $ipaclient::params::sshd,
   $sudo               = $ipaclient::params::sudo,
+  $hostname           = $ipaclient::params::hostname,
 ) inherits ipaclient::params {
 
   package { $package:
@@ -132,6 +135,12 @@ class ipaclient (
         $opt_domain = ['--domain', $domain]
       } else {
         $opt_domain = ''
+      }
+
+      if $hostname {
+        $opt_hostname = ['--hostname', $hostname]
+      } else {
+        $opt_hostname = ''
       }
 
       if $realm {
@@ -190,7 +199,7 @@ class ipaclient (
 
       # Flatten the arrays, delete empty options, and shellquote everything
       $command = shellquote(delete(flatten([$installer,$opt_realm,$opt_password,
-                            $opt_principal,$opt_mkhomedir,$opt_domain,
+                            $opt_principal,$opt_mkhomedir,$opt_domain,$opt_hostname,
                             $opt_server,$opt_fixed_primary,$opt_ssh,$opt_sshd,$opt_ntp,$opt_sudo,
                             $opt_force,$options,'--unattended']), ''))
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,9 +5,10 @@
 class ipaclient::params {
 
   $server         = ''
-  $domain         = ''
-  $realm          = ''
-  $principal      = ''
+  $hostname       = undef
+  $domain         = undef
+  $realm          = undef
+  $principal      = undef
   $password       = ''
   $ntp_server     = ''
   $ssh            = true
@@ -37,7 +38,7 @@ class ipaclient::params {
       case $::operatingsystem {
         'Fedora': {
           if (versioncmp($::operatingsystemrelease, '21') >= 0) {
-            $needs_sudo_config = false 
+            $needs_sudo_config = false
           } else {
             $needs_sudo_config = true
           }

--- a/spec/classes/ipaclient_spec.rb
+++ b/spec/classes/ipaclient_spec.rb
@@ -103,6 +103,7 @@ describe 'ipaclient' do
         :principal => "rainbows",
         :server    => "ipa01.pixiedust.com",
         :domain    => "pixiedust.com",
+        :hostname  => "client.pixiedust.com",
         :realm     => "PIXIEDUST.COM",
         :sudo      => false,
         :automount => true,
@@ -116,7 +117,7 @@ describe 'ipaclient' do
       end
 
       it "should generate the correct command" do
-        should contain_exec('ipa_installer').with_command("/usr/sbin/ipa-client-install --realm PIXIEDUST.COM --password unicorns --principal rainbows@PIXIEDUST.COM --domain pixiedust.com --server ipa01.pixiedust.com --no-sudo --unattended")
+        should contain_exec('ipa_installer').with_command("/usr/sbin/ipa-client-install --realm PIXIEDUST.COM --password unicorns --principal rainbows@PIXIEDUST.COM --domain pixiedust.com --hostname client.pixiedust.com --server ipa01.pixiedust.com --no-sudo --unattended")
       end
 
       it "should not configure sudoers" do


### PR DESCRIPTION
Also, fixed optional parameter processing for realm, domain, principal.
When these are not specified, they need to be set to undef to ensure
correct processing. Empty string is converted to True, causing incorrect
processing.

Also, removed extra space to fix linter error.