### PR TITLE
If sssd isn't installed or /etc/sssd/sssd.conf doesn't exist set ipa_enrolled to false

### DIFF
--- a/lib/facter/ipa_facts.rb
+++ b/lib/facter/ipa_facts.rb
@@ -32,6 +32,15 @@ if File.exist?('/etc/sssd/sssd.conf') && sssd = File.readlines('/etc/sssd/sssd.c
   end
 end
 
+# If sssd isn't installed, ipa isn't enrolled
+if not File.exist?('/etc/sssd/sssd.conf')
+  Facter.add("ipa_enrolled") do
+    setcode do
+      false
+    end
+  end
+end
+
 # In the event we can't find the records from SSSD, we'll use DNS
 if Facter.value(:ipa_server).nil? || Facter.value(:ipa_domain).nil?
   begin


### PR DESCRIPTION
We recently enabled strict_variables and we ran into the following error when provisioning a new host.

`Server Error: Evaluation Error: Unknown variable: '::ipa_enrolled'.`

This could probably be mitigated by installing the IPA client packages during the kickstart or something, but we let the module handle that.