### PR TITLE
Fixed OS Switch and Add Debian Support

### DIFF
--- a/lib/facter/ipa_facts.rb
+++ b/lib/facter/ipa_facts.rb
@@ -1,6 +1,14 @@
 require 'facter'
 require 'resolv'
 
+Facter.add('ipa_client_version') do
+  setcode do
+    if Facter::Util::Resolution.which('ipa-client-install')
+      Facter::Util::Resolution.exec('ipa-client-install --version')
+    end
+  end
+end
+
 if File.exist?('/etc/sssd/sssd.conf') && sssd = File.readlines('/etc/sssd/sssd.conf')
   sssd.each do |line|
     case line

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,9 @@
 # $sshd::                  Enable SSHD Integration
 #                          Default: true
 #
+# $subid::                 Use SSSD as subid provider
+#                          Default: false
+#
 # $sudo::                  Enable sudoers management
 #                          Default: true
 #
@@ -109,6 +112,7 @@ class ipaclient (
   $server             = $ipaclient::params::server,
   $ssh                = $ipaclient::params::ssh,
   $sshd               = $ipaclient::params::sshd,
+  $subid              = $ipaclient::params::subid,
   $sudo               = $ipaclient::params::sudo,
   $hostname           = $ipaclient::params::hostname,
   $force_join         = $ipaclient::params::force_join
@@ -196,6 +200,12 @@ class ipaclient (
         $opt_force = ''
       }
 
+      if versioncmp($::ipa_client_version, "4.9.10") >= 0 and str2bool($subid) {
+        $opt_subid = '--subid'
+      } else {
+        $opt_subid = ''
+      }
+
       if !str2bool($sudo) {
         $opt_sudo = '--no-sudo'
       } else {
@@ -211,8 +221,9 @@ class ipaclient (
       # Flatten the arrays, delete empty options, and shellquote everything
       $command = shellquote(delete(flatten([$installer,$opt_realm,$opt_password,
                             $opt_principal,$opt_mkhomedir,$opt_domain,$opt_hostname,
-                            $opt_server,$opt_fixed_primary,$opt_ssh,$opt_sshd,$opt_ntp,$opt_sudo,
-                            $opt_force,$opt_force_join,$options,'--unattended']), ''))
+                            $opt_server,$opt_fixed_primary,$opt_ssh,$opt_sshd,$opt_ntp,
+                            $opt_sudo,$opt_subid,$opt_force,$opt_force_join,$options,
+                            '--unattended']), ''))
 
       exec { 'ipa_installer':
         command => $command,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -200,7 +200,9 @@ class ipaclient (
         $opt_force = ''
       }
 
-      if versioncmp($::ipa_client_version, "4.9.10") >= 0 and str2bool($subid) {
+      if !empty($::ipa_client_version) and
+         versioncmp($::ipa_client_version, "4.9.10") >= 0 and
+         str2bool($subid) {
         $opt_subid = '--subid'
       } else {
         $opt_subid = ''

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -227,11 +227,15 @@ class ipaclient (
                             $opt_sudo,$opt_subid,$opt_force,$opt_force_join,$options,
                             '--unattended']), ''))
 
-      exec { 'ipa_installer':
-        command => $command,
-        unless  => "/usr/sbin/ipa-client-install -U 2>&1 \
-          | /bin/grep -q 'already configured'",
-        require => Package[$package],
+      # Make sure we can collect the `ipa_client_version` fact first
+      # Makes us run twice, though :(
+      if !empty($::ipa_client_version) {
+        exec { 'ipa_installer':
+          command => $command,
+          unless  => "/usr/sbin/ipa-client-install -U 2>&1 \
+            | /bin/grep -q 'already configured'",
+          require => Package[$package],
+        }
       }
 
       $installer_resource = Exec['ipa_installer']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,7 @@ class ipaclient (
   $ntp                = $ipaclient::params::ntp,
   $options            = $ipaclient::params::options,
   $package            = $ipaclient::params::package,
+  $package_options    = $ipaclient::params::package_options,
   $password           = $ipaclient::params::password,
   $principal          = $ipaclient::params::principal,
   $realm              = $ipaclient::params::realm,
@@ -115,6 +116,7 @@ class ipaclient (
 
   package { $package:
     ensure => installed,
+    install_options => $package_options,
   }
 
   if !str2bool($::ipa_enrolled) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -268,18 +268,32 @@ class ipaclient (
       $sudo_domain = $domain
     }
 
-    class { 'ipaclient::sudoers':
-      server  => $sudo_server,
-      domain  => $sudo_domain,
-      require => $installer_resource,
+    if !str2bool($::ipa_enrolled) {
+      class { 'ipaclient::sudoers':
+        server  => $sudo_server,
+        domain  => $sudo_domain,
+        require => $installer_resource,
+      }
+    } else {
+      class { 'ipaclient::sudoers':
+        server  => $sudo_server,
+        domain  => $sudo_domain,
+      }
     }
   }
 
   if str2bool($automount) {
-    class { 'ipaclient::automount':
-        location => $automount_location,
-        server   => $automount_server,
-        require  => $installer_resource,
+    if !str2bool($::ipa_enrolled) {
+      class { 'ipaclient::automount':
+          location => $automount_location,
+          server   => $automount_server,
+          require  => $installer_resource,
+      }
+    } else {
+      class { 'ipaclient::automount':
+          location => $automount_location,
+          server   => $automount_server,
+      }
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,7 +131,7 @@ class ipaclient (
 
       $opt_password = ['--password', $password]
 
-      if is_array($server) {
+      if $server =~ Array {
         # Transform ['a','b'] -> ['--server','a','--server','b']
         $opt_server = split(join(prefix($server, '--server|'), '|'), '\|')
       } elsif !empty($server) {
@@ -255,7 +255,7 @@ class ipaclient (
     # the first value of server parameter
     if empty($server) {
       $sudo_server = $::ipa_server
-    } elsif is_array($server) {
+    } elsif $server =~ Array {
       $sudo_server = $server[0]
     } else {
       $sudo_server = $server

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -268,32 +268,18 @@ class ipaclient (
       $sudo_domain = $domain
     }
 
-    if !str2bool($::ipa_enrolled) {
-      class { 'ipaclient::sudoers':
-        server  => $sudo_server,
-        domain  => $sudo_domain,
-        require => $installer_resource,
-      }
-    } else {
-      class { 'ipaclient::sudoers':
-        server  => $sudo_server,
-        domain  => $sudo_domain,
-      }
+    class { 'ipaclient::sudoers':
+      server  => $sudo_server,
+      domain  => $sudo_domain,
+      require => $installer_resource,
     }
   }
 
   if str2bool($automount) {
-    if !str2bool($::ipa_enrolled) {
-      class { 'ipaclient::automount':
-          location => $automount_location,
-          server   => $automount_server,
-          require  => $installer_resource,
-      }
-    } else {
-      class { 'ipaclient::automount':
-          location => $automount_location,
-          server   => $automount_server,
-      }
+    class { 'ipaclient::automount':
+        location => $automount_location,
+        server   => $automount_server,
+        require  => $installer_resource,
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class ipaclient::params {
   $sshd           = true
   $automount      = false
   $mkhomedir      = true
+  $subid          = false
   $sudo           = true
   $fixed_primary  = false
   $options        = ''

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,6 +28,7 @@ class ipaclient::params {
   $sssd_sudo_smart_refresh     = ''
   $sssd_default_domain_suffix  = ''
   $force_join     = false
+  $package_options = []
 
   # Determine if client needs manual sudo configuration or not
   # RHEL <=6.5 requires manual configuration

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,7 @@ class ipaclient::params {
   # RHEL 6.6 includes automatic sudo configuration
   # RHEL 7.0 requires manual confifuration
   # RHEL >=7.1 includes automatic sudo configuration
-  case $::osfamily {
+  case $facts['os']['family'] {
     'RedHat': {
       case $::operatingsystem {
         'Fedora': {
@@ -74,12 +74,12 @@ class ipaclient::params {
       }
     }
     default: {
-      fail("This module does not support operatingsystem ${::operatingsystem}")
+      fail("This module does not support os family " + facts['os']['family'])
     }
   }
 
   # Name of IPA package to install
-  case $::osfamily {
+  case $facts['os']['family'] {
     'RedHat': {
       case $::operatingsystem {
         'fedora': {
@@ -94,7 +94,7 @@ class ipaclient::params {
         $package = 'freeipa-client'
     }
     default: {
-      fail("This module does not support operatingsystem ${::operatingsystem}")
+      fail("This module does not support os family " + $facts['os']['family'])
     }
   }
 }

--- a/manifests/sudoers.pp
+++ b/manifests/sudoers.pp
@@ -97,16 +97,19 @@ class ipaclient::sudoers (
     # Selecting the right provider is a PITA
     if empty($::sssd_version) {
       case $::osfamily {
-        RedHat: {
+        'RedHat': {
           if (versioncmp($::operatingsystemrelease, '6.6') >= 0) {
             $ipa_provider = 'ipa'
           } else {
             $ipa_provider = 'ldap'
           }
         }
-        Debian: {
+        'Debian': {
           if (versioncmp($::operatingsystemrelease, '14.04') >= 0 and
             $::operatingsystem == 'Ubuntu') {
+            $ipa_provider = 'ipa'
+          } elsif (versioncmp($::operatingsystemrelease, '7.0') >= 0 and
+            $::operatingsystem == 'Debian') {
             $ipa_provider = 'ipa'
           } else {
             $ipa_provider = 'ldap'

--- a/manifests/sudoers.pp
+++ b/manifests/sudoers.pp
@@ -109,7 +109,7 @@ class ipaclient::sudoers (
             $::operatingsystem == 'Ubuntu') {
             $ipa_provider = 'ipa'
           } elsif (versioncmp($::operatingsystemrelease, '7.0') >= 0 and
-            $::operatingsystem == 'Debian') {
+            ($::operatingsystem == 'Debian' or $::operatingsystem == 'Raspbian')) {
             $ipa_provider = 'ipa'
           } else {
             $ipa_provider = 'ldap'

--- a/manifests/sudoers.pp
+++ b/manifests/sudoers.pp
@@ -33,7 +33,7 @@ class ipaclient::sudoers (
   if !empty($server) and !empty($domain) {
     $realm = upcase($domain)
 
-    case $::osfamily {
+    case $facts['os']['family'] {
       'RedHat': {
 
         if ($::operatingsystem == 'Fedora' and


### PR DESCRIPTION
The cases in the OS switch statement if the version of SSSD can't be found weren't quoted, which caused Puppet to fail.

Also, added support for Debian users who use external repos to get freeipa-client packages (ex. numeezy) and the official repos for Sid which include FreeIPA.